### PR TITLE
Use the Provider class's classloader to load implementations

### DIFF
--- a/api/src/main/java/org/cloudburstmc/math/MathImplementationLoader.java
+++ b/api/src/main/java/org/cloudburstmc/math/MathImplementationLoader.java
@@ -24,19 +24,11 @@
  */
 package org.cloudburstmc.math;
 
-import javax.annotation.Nonnull;
-import java.util.Objects;
 import java.util.ServiceLoader;
 
 public final class MathImplementationLoader {
 
-    private static ClassLoader CLASS_LOADER = Thread.currentThread().getContextClassLoader();
-
-    public static void setClassLoader(@Nonnull ClassLoader classLoader) {
-        CLASS_LOADER = Objects.requireNonNull(classLoader);
-    }
-
     public static <S> ServiceLoader<S> serviceLoader(Class<S> service) {
-        return ServiceLoader.load(service, CLASS_LOADER);
+        return ServiceLoader.load(service, service.getClassLoader());
     }
 }

--- a/api/src/main/java/org/cloudburstmc/math/MathImplementationLoader.java
+++ b/api/src/main/java/org/cloudburstmc/math/MathImplementationLoader.java
@@ -22,41 +22,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.cloudburstmc.math.imaginary;
+package org.cloudburstmc.math;
 
-import org.cloudburstmc.math.MathImplementationLoader;
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.ServiceLoader;
 
-import java.util.Iterator;
+public final class MathImplementationLoader {
 
-class Imaginary {
-    private static ImaginaryProvider cached;
+    private static ClassLoader CLASS_LOADER = Thread.currentThread().getContextClassLoader();
 
-    public static ImaginaryProvider provider() {
-        if (cached != null) {
-            return cached;
-        }
-
-        Iterator<ImaginaryProvider> iterator = MathImplementationLoader.serviceLoader(ImaginaryProvider.class).iterator();
-        if (!iterator.hasNext()) {
-            throw new RuntimeException("Could not initialize imaginary provider as no implementation was provided!");
-        }
-
-        return cached = iterator.next();
+    public static void setClassLoader(@Nonnull ClassLoader classLoader) {
+        CLASS_LOADER = Objects.requireNonNull(classLoader);
     }
 
-    public static Complexd createComplexd(double x, double y) {
-        return provider().createComplexd(x, y);
-    }
-
-    public static Complexf createComplexf(float x, float y) {
-        return provider().createComplexf(x, y);
-    }
-
-    public static Quaterniond createQuaterniond(double x, double y, double z, double w) {
-        return provider().createQuaterniond(x, y, z, w);
-    }
-
-    public static Quaternionf createQuaternionf(float x, float y, float z, float w) {
-        return provider().createQuaternionf(x, y, z, w);
+    public static <S> ServiceLoader<S> serviceLoader(Class<S> service) {
+        return ServiceLoader.load(service, CLASS_LOADER);
     }
 }

--- a/api/src/main/java/org/cloudburstmc/math/vector/Vectors.java
+++ b/api/src/main/java/org/cloudburstmc/math/vector/Vectors.java
@@ -24,11 +24,11 @@
  */
 package org.cloudburstmc.math.vector;
 
+import org.cloudburstmc.math.MathImplementationLoader;
+
 import java.util.Iterator;
-import java.util.ServiceLoader;
 
 class Vectors {
-    private static final ServiceLoader<VectorProvider> VECTOR_PROVIDER_LOADER = ServiceLoader.load(VectorProvider.class);
     private static VectorProvider cached;
     
     public static VectorProvider provider() {
@@ -36,7 +36,7 @@ class Vectors {
             return cached;
         }
     
-        Iterator<VectorProvider> iterator = VECTOR_PROVIDER_LOADER.iterator();
+        Iterator<VectorProvider> iterator = MathImplementationLoader.serviceLoader(VectorProvider.class).iterator();
         if (!iterator.hasNext()) {
             throw new RuntimeException("Could not initialize vector provider as no implementation was provided!");
         }


### PR DESCRIPTION
`ServiceLoader.load(service)` uses `Thread.currentThread().getContextClassLoader()` which doesn't work on platforms like Spigot. 

This was tested on PaperMC/BungeeCord/Velocity of Geyser